### PR TITLE
DevContainerのユーザを通常のユーザにする

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,4 +6,6 @@
   ],
   "service": "app",
   "workspaceFolder": "/usr/src/app",
+  "remoteUser": "${localEnv:USER}",
+  "overrideCommand": false
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,16 @@ FROM ruby:3.4.5
 
 ENV LANG C.UTF-8
 
+ARG USERNAME
+ARG USER_UID
+ARG USER_GID
+
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME -s /bin/bash \
+    && apt-get update && apt-get install -y sudo \
+    && echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
@@ -21,4 +31,5 @@ RUN gem install bundler -v '2.6.9'
 RUN bundle install
 
 EXPOSE 3000
+USER $USERNAME
 CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,16 @@
 services:
   app:
     container_name: intern-app
-    build: .
-    command: /bin/bash -l -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        USERNAME: ${USER:-vscode}
+        USER_UID: ${UID:-1000}
+        USER_GID: ${GID:-1000}
+    command: >
+      /bin/bash -l -c "rm -f tmp/pids/server.pid &&
+      bundle exec rails s -p 3000 -b '0.0.0.0'"
     ports:
       - "3000:3000"
     environment:


### PR DESCRIPTION
DevContainer内のターミナルはデフォルトでrootユーザを使うので、`rails generate`などで作ったファイルもrootユーザの管理下になり、root権限でないと削除、編集できません。

普段使っているユーザでログインするように変更しました。