### PR TITLE
fix issue 15 - ポスト中のURLをリンクとして表示するようにした

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,9 @@
 module ApplicationHelper
+  # thanks: https://qiita.com/d-haru/items/11f961535e3c7bd64d71
+  def convert_url_to_a_element(text)
+    uri_reg = URI.regexp(%w[http https])
+    text.gsub(uri_reg) { %{<a href='#{$&}' target='_blank'>#{$&}</a>} }
+  end
 
   # ページごとの完全なタイトルを返します。                   # コメント行
   def full_title(page_title = '')                     # メソッド定義とオプション引数

--- a/app/views/microposts/_micropost.html.erb
+++ b/app/views/microposts/_micropost.html.erb
@@ -2,7 +2,7 @@
   <%= link_to gravatar_for(micropost.user, size: 50), micropost.user %>
   <span class="user"><%= link_to micropost.user.name, micropost.user %></span>
   <span class="content">
-    <%= micropost.content %>
+    <%= raw convert_url_to_a_element(simple_format(micropost.content, sanitize: true)) %>
     <% if micropost.image.attached? %>
       <%= image_tag micropost.image.variant(:display) %>
     <% end %>


### PR DESCRIPTION
issue #15 にある通り，マイクロポスト本文に「http://」または「https://」から始まる文章が存在する場合はリンク化するようにした。